### PR TITLE
Compatibility with any React version

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,7 +32,7 @@ export default [
       terser(),
       postcss()
     ],
-    external: ['react', 'react-dom']
+    external: ['react', 'react-dom', 'react/jsx-runtime']
   },
   {
     input: 'src/index.ts',


### PR DESCRIPTION
This specifies `react/jsx-runtime` as an external dependency, which removes it from the bundled file. By importing it dynamically, it should now generally work with any version of React, not just the one it was bundled with.

(This fixes compatibility with React v19, while retaining compatibility with React v18 and possibly older)