### PR TITLE
Component cleanup

### DIFF
--- a/templates/svg.js
+++ b/templates/svg.js
@@ -3,7 +3,7 @@ const propTypesTemplate = (
   { tpl }
 ) => {
   return tpl`import '../style.css';
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 import { IonIconProps } from '../types';
 ${interfaces}
 
@@ -14,18 +14,7 @@ function ${componentName}({
   beat,
   ...props
 }: IonIconProps) {
-  const animation = useMemo(() => {
-    if (spin) {
-      return 'spin';
-    }
-
-    if (beat) {
-      return 'beat';
-    }
-
-    return '';
-  }, [spin]);
-
+  const animation = (spin && 'spin') || (beat && 'beat');
   return ${jsx};
 }
 


### PR DESCRIPTION
Previously the animation string was calculated with a useMemo hook. The hook was missing the `beat` dependency, and was partially broken as a result. It likely worked anyway, since SVGR memoized the entire component, and would trigger a re-render if any of the props changed regardless of the hook.

This removes the use of useMemo entirely, since setting the animation string is not computationally complex, so there's little to no benefit to the useMemo hook in addition to the already-memoized component.